### PR TITLE
Fix definition of procedure table in Hibernate mapping files

### DIFF
--- a/spi-impl/series/series-mappings/src/main/hbm/sos/v42/series/PlatformResource.hbm.xml
+++ b/spi-impl/series/series-mappings/src/main/hbm/sos/v42/series/PlatformResource.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping package="org.n52.series.db.beans">
-  <class name="PlatformEntity" table="procedure">
+  <class name="PlatformEntity" table="`procedure`">
     <id name="pkid" type="long">
       <column name="procedureid"/>
       <generator class="assigned"/>

--- a/spi-impl/series/series-mappings/src/main/hbm/sos/v44/PlatformResource.hbm.xml
+++ b/spi-impl/series/series-mappings/src/main/hbm/sos/v44/PlatformResource.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping package="org.n52.series.db.beans">
-  <class name="PlatformEntity" table="procedure">
+  <class name="PlatformEntity" table="`procedure`">
     <id name="pkid" type="long">
       <column name="procedureid"/>
       <generator class="assigned"/>


### PR DESCRIPTION
This fixes issues with the databases where the the `procedure` is a reserved word. The procedure mapping files already contain the valid definition.