### PR TITLE
Fix/set static service entity within data repository

### DIFF
--- a/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/AbstractDataRepository.java
+++ b/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/AbstractDataRepository.java
@@ -43,13 +43,9 @@ import org.n52.series.db.beans.parameter.Parameter;
 import org.n52.series.db.dao.DataDao;
 import org.n52.series.db.dao.DatasetDao;
 import org.n52.series.db.dao.DbQuery;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public abstract class AbstractDataRepository<D extends Data<?>, DSE extends DatasetEntity<?>, DE extends DataEntity<?>, V extends AbstractValue<?>>
         extends SessionAwareRepository implements DataRepository<DSE, V> {
-
-    @Autowired
-    private PlatformRepository platformRepository;
 
     @Override
     public Data<?> getData(String seriesId, DbQuery dbQuery) throws DataAccessException {
@@ -58,7 +54,6 @@ public abstract class AbstractDataRepository<D extends Data<?>, DSE extends Data
             DatasetDao<DSE> seriesDao = getSeriesDao(session);
             String id = DatasetType.extractId(seriesId);
             DSE series = seriesDao.getInstance(id, dbQuery);
-            series.setPlatform(platformRepository.getPlatformEntity(series, dbQuery, session));
             return dbQuery.isExpanded()
                 ? assembleDataWithReferenceValues(series, dbQuery, session)
                 : assembleData(series, dbQuery, session);

--- a/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/AbstractDataRepository.java
+++ b/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/AbstractDataRepository.java
@@ -54,6 +54,9 @@ public abstract class AbstractDataRepository<D extends Data<?>, DSE extends Data
             DatasetDao<DSE> seriesDao = getSeriesDao(session);
             String id = DatasetType.extractId(seriesId);
             DSE series = seriesDao.getInstance(id, dbQuery);
+            if (series.getService() == null) {
+                series.setService(getStaticServiceEntity());
+            }
             return dbQuery.isExpanded()
                 ? assembleDataWithReferenceValues(series, dbQuery, session)
                 : assembleData(series, dbQuery, session);

--- a/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/DataRepository.java
+++ b/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/DataRepository.java
@@ -34,6 +34,7 @@ import org.n52.io.response.dataset.Data;
 import org.n52.series.db.DataAccessException;
 import org.n52.series.db.HibernateSessionStore;
 import org.n52.series.db.beans.DatasetEntity;
+import org.n52.series.db.beans.ServiceEntity;
 import org.n52.series.db.dao.DbQuery;
 
 public interface DataRepository<DSE extends DatasetEntity<?>, V extends AbstractValue<?>> {
@@ -45,6 +46,10 @@ public interface DataRepository<DSE extends DatasetEntity<?>, V extends Abstract
     V getLastValue(DSE entity, Session session, DbQuery query);
 
     void setSessionStore(HibernateSessionStore sessionStore);
+    
+    default void setStaticServiceEntity(ServiceEntity serviceEntity) {
+        // void
+    }
 
     Class<DSE> getEntityType();
 }

--- a/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/DefaultDataRepositoryFactory.java
+++ b/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/DefaultDataRepositoryFactory.java
@@ -32,6 +32,7 @@ import java.io.File;
 
 import org.n52.io.ConfigTypedFactory;
 import org.n52.series.db.HibernateSessionStore;
+import org.n52.series.db.beans.ServiceEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class DefaultDataRepositoryFactory extends ConfigTypedFactory<DataRepository> implements IDataRepositoryFactory {
@@ -42,6 +43,9 @@ public class DefaultDataRepositoryFactory extends ConfigTypedFactory<DataReposit
 
     @Autowired
     private HibernateSessionStore sessionStore;
+    
+    @Autowired
+    private ServiceEntity serviceEntity;
 
     public DefaultDataRepositoryFactory() {
         super(DEFAULT_CONFIG_FILE);
@@ -54,6 +58,10 @@ public class DefaultDataRepositoryFactory extends ConfigTypedFactory<DataReposit
     @Override
     protected DataRepository initInstance(DataRepository instance) {
         instance.setSessionStore(sessionStore);
+        if (serviceEntity != null) {
+            // static instance available from Spring config
+            instance.setStaticServiceEntity(serviceEntity);
+        }
         return instance;
     }
 
@@ -73,6 +81,14 @@ public class DefaultDataRepositoryFactory extends ConfigTypedFactory<DataReposit
 
     public void setSessionStore(HibernateSessionStore sessionStore) {
         this.sessionStore = sessionStore;
+    }
+
+    public ServiceEntity getServiceEntity() {
+        return serviceEntity;
+    }
+
+    public void setServiceEntity(ServiceEntity serviceEntity) {
+        this.serviceEntity = serviceEntity;
     }
 
 }

--- a/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
+++ b/spi-impl/series/series-dao/src/main/java/org/n52/series/db/da/SessionAwareRepository.java
@@ -190,6 +190,10 @@ public abstract class SessionAwareRepository {
     protected OfferingOutput getCondensedExtendedOffering(OfferingEntity entity, DbQuery parameters) {
         return createCondensed(new OfferingOutput(), entity, parameters, urHelper.getOfferingsHrefBaseUrl(parameters.getHrefBase()));
     }
+    
+    public void setStaticServiceEntity(ServiceEntity serviceEntity) {
+        this.serviceEntity = serviceEntity;
+    }
 
     protected ServiceEntity getStaticServiceEntity() {
         return serviceEntity;


### PR DESCRIPTION
After introducing the option to allow multiple service entities (see [PR proxy dev](https://github.com/52North/series-rest-api/pull/291) or better the [separated dev line](https://github.com/52North/series-sos-proxy)), data repositories have to set `ServiceEntity` when [configured statically via Spring](https://github.com/52North/series-rest-api/blob/develop/spi-impl/series/series-dao-webapp/src/main/webapp/WEB-INF/spring/spi-impl-dao_common.xml#L16-L21).