### PR TITLE
Added Version header to HTTP Response

### DIFF
--- a/rest/src/main/java/org/n52/web/ctrl/ResourcesController.java
+++ b/rest/src/main/java/org/n52/web/ctrl/ResourcesController.java
@@ -30,6 +30,7 @@ package org.n52.web.ctrl;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.servlet.http.HttpServletResponse;
 
 import org.n52.io.I18N;
 import org.n52.io.request.FilterResolver;
@@ -49,7 +50,9 @@ public class ResourcesController {
     private CountingMetadataService metadataService;
 
     @RequestMapping("/")
-    public ModelAndView getResources(@RequestParam(required = false) MultiValueMap<String, String> parameters) {
+    public ModelAndView getResources(HttpServletResponse response,
+                                     @RequestParam(required = false) MultiValueMap<String, String> parameters) {
+        this.addVersionHeader(response);
         IoParameters query = QueryParameters.createFromQuery(parameters);
         query = IoParameters.ensureBackwardsCompatibility(query);
         return new ModelAndView().addObject(createResources(query));
@@ -111,6 +114,10 @@ public class ResourcesController {
         }
 
         return resources;
+    }
+
+    private void addVersionHeader(HttpServletResponse response){
+        response.addHeader("API-Version", this.getClass().getPackage().getImplementationVersion());
     }
 
     public CountingMetadataService getMetadataService() {

--- a/rest/src/main/java/org/n52/web/ctrl/ResourcesController.java
+++ b/rest/src/main/java/org/n52/web/ctrl/ResourcesController.java
@@ -116,7 +116,7 @@ public class ResourcesController {
         return resources;
     }
 
-    private void addVersionHeader(HttpServletResponse response){
+    private void addVersionHeader(HttpServletResponse response) {
         response.addHeader("API-Version", this.getClass().getPackage().getImplementationVersion());
     }
 

--- a/web-resources/src/main/docs/compatibility.md
+++ b/web-resources/src/main/docs/compatibility.md
@@ -10,6 +10,15 @@ add new content to existing data structures (which won't break backwards compabi
 
 Also new endpoints may be introduced over time like we did in `v2.0.0`.
 
+### Version Information
+
+The API provides Information about the current Version in a custom HTTP Response Header, returned on the `/` Endpoint.
+```
+[...]
+API-Version: 1.2.3
+[...]
+```
+
 ## Version 2.0.0
 
 ### New Endpoints


### PR DESCRIPTION
Implements Version Header as suggested in #384 . 

Information is read from Package Version Information and delivered via custom HTTP Response Header on `/` Endpoint.