### PR TITLE
V2.x/fix backwards compatibility issues

### DIFF
--- a/io/src/main/java/org/n52/io/IoStyleContext.java
+++ b/io/src/main/java/org/n52/io/IoStyleContext.java
@@ -81,30 +81,23 @@ public final class IoStyleContext {
     private static void associateBackwardsCompatibleSingleStyle(IoParameters parameters,
                                                                 List< ? extends DatasetOutput< ? , ? >> metadatas,
                                                                 Map<String, StyleProperties> styles) {
-        StyleProperties style = parameters.getSingleStyle();
-        if (style != null) {
-            if (metadatas.size() == 0) {
-                throw new IllegalArgumentException("No metadatas found for given style.");
-            }
-            styles.put(metadatas.get(0).getId(), style);
+        if (styles.isEmpty() && metadatas.size() == 1) {
+            // no referenced styles are given so associate
+            // backwards compatible single style
+            DatasetOutput< ? , ? > metadata = metadatas.get(0);
+            styles.put(metadata.getId(), parameters.getSingleStyle());
         }
-
     }
 
     private static Map<String, StyleMetadata> collectStyleMetadatas(List< ? extends DatasetOutput< ? , ? >> metadatas,
                                                                     final Map<String, StyleProperties> styles) {
         return metadatas.stream()
-                        .<StyleMetadata> map(e -> {
+                        .map(e -> {
                             return new StyleMetadata().setDatasetMetadata(e)
                                                       .setDatasetId(e.getId())
                                                       .setStyleProperties(styles.get(e.getId()));
                         })
                         .collect(Collectors.toMap(StyleMetadata::getDatasetId, Function.identity()));
-    }
-
-    public static IoStyleContext createContextForSingleSeries(DatasetOutput< ? , ? > metadata,
-                                                              IoParameters parameters) {
-        return createContextWith(parameters, Collections.singletonList(metadata));
     }
 
     public List<DatasetOutput< ? , ? >> getAllDatasetMetadatas() {

--- a/io/src/test/java/org/n52/io/img/quantity/ChartRendererTest.java
+++ b/io/src/test/java/org/n52/io/img/quantity/ChartRendererTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.n52.io.request.IoParameters.createDefaults;
 
+import java.util.Collections;
 import java.util.Date;
 
 import org.joda.time.DateTime;
@@ -135,48 +136,50 @@ public class ChartRendererTest {
     public void shouldFormatTitleTemplateWhenPrerenderingTriggerIsActive() {
 
         QuantityDatasetOutput metadata = new QuantityDatasetOutput();
-        DatasetParameters parameters = new DatasetParameters();
-        parameters.setCategory(createParameter(new CategoryOutput(), "cat_1", "category"));
-        parameters.setFeature(createParameter(new FeatureOutput(), "feat_1", "feature"));
-        parameters.setOffering(createParameter(new OfferingOutput(), "off_1", "offering"));
-        parameters.setPhenomenon(createParameter(new PhenomenonOutput(), "phen_1", "phenomenon"));
-        parameters.setProcedure(createParameter(new ProcedureOutput(), "proc_1", "procedure"));
-        parameters.setService(createParameter(new ServiceOutput(), "ser_1", "service"));
-        metadata.setDatasetParameters(parameters);
+        DatasetParameters datasetParameters = new DatasetParameters();
+        datasetParameters.setCategory(createParameter(new CategoryOutput(), "cat_1", "category"));
+        datasetParameters.setFeature(createParameter(new FeatureOutput(), "feat_1", "feature"));
+        datasetParameters.setOffering(createParameter(new OfferingOutput(), "off_1", "offering"));
+        datasetParameters.setPhenomenon(createParameter(new PhenomenonOutput(), "phen_1", "phenomenon"));
+        datasetParameters.setProcedure(createParameter(new ProcedureOutput(), "proc_1", "procedure"));
+        datasetParameters.setService(createParameter(new ServiceOutput(), "ser_1", "service"));
+        metadata.setDatasetParameters(datasetParameters);
         metadata.setId("timeseries");
         metadata.setUom("");
 
         PlatformOutput platformOutput = new PlatformOutput(PlatformType.STATIONARY_INSITU);
         platformOutput.setId("sta_1");
         platformOutput.setLabel("station");
-        parameters.setPlatform(platformOutput);
+        datasetParameters.setPlatform(platformOutput);
 
         // build expected title
         StringBuilder expected = new StringBuilder();
-        expected.append(parameters.getPlatform()
-                                  .getLabel());
+        ParameterOutput platform = datasetParameters.getPlatform();
+        expected.append(platform.getLabel());
+        ParameterOutput phenomenon = datasetParameters.getPhenomenon();
+        ParameterOutput procedure = datasetParameters.getProcedure();
+        ParameterOutput offering = datasetParameters.getOffering();
+        ParameterOutput feature = datasetParameters.getFeature();
+        ParameterOutput service = datasetParameters.getService();
+        ParameterOutput category = datasetParameters.getCategory();
         expected.append(" ")
-                .append(parameters.getPhenomenon()
-                                  .getLabel());
-        expected.append(" ")
-                .append(parameters.getProcedure()
-                                  .getLabel());
-        // expected.append(" ").append(parameters.getCategory().getLabel());
-        expected.append(" (4 opted-out)");
-        expected.append(" ")
-                .append(parameters.getOffering()
-                                  .getLabel());
-        expected.append(" ")
-                .append(parameters.getFeature()
-                                  .getLabel());
-        expected.append(" ")
-                .append(parameters.getService()
-                                  .getLabel());
-        expected.append(" ")
+                .append(phenomenon.getLabel())
+                .append(" ")
+                .append(procedure.getLabel())
+                // .append(" ")
+                // .append(category.getLabel())
+                .append(" (4 opted-out)")
+                .append(" ")
+                .append(offering.getLabel())
+                .append(" ")
+                .append(feature.getLabel())
+                .append(" ")
+                .append(service.getLabel())
+                .append(" ")
                 .append(metadata.getUom());
 
         IoParameters ioConfig = createDefaults().extendWith("rendering_trigger", "prerendering");
-        IoStyleContext context = IoStyleContext.createContextForSingleSeries(metadata, ioConfig);
+        IoStyleContext context = IoStyleContext.createContextWith(ioConfig, Collections.singletonList(metadata));
         MyChartRenderer chartRenderer = new MyChartRenderer(ioConfig, context);
         // String template = "%1$s %2$s %3$s %4$s %5$s %6$s %7$s %8$s";
         String template = "%1$s %2$s %3$s (4 opted-out) %5$s %6$s %7$s %8$s";

--- a/rest/src/main/java/org/n52/web/ctrl/BaseController.java
+++ b/rest/src/main/java/org/n52/web/ctrl/BaseController.java
@@ -82,7 +82,7 @@ public abstract class BaseController implements ServletConfigAware {
 
     private static final String REFER_TO_API_SYNTAX = "Refer to the API documentation and check parameter "
             + "value against required syntax!";
-    
+
     private static final String INVALID_REQUEST_BODY = "Check the request body which has been sent to the "
             + "server. Probably it is not valid.";
 

--- a/rest/src/main/java/org/n52/web/ctrl/TimeseriesDataController.java
+++ b/rest/src/main/java/org/n52/web/ctrl/TimeseriesDataController.java
@@ -161,7 +161,7 @@ public class TimeseriesDataController extends BaseController {
                                 @RequestHeader(value = Parameters.HttpHeader.ACCEPT_LANGUAGE,
                                     required = false) String locale,
                                 @RequestParam(required = false) MultiValueMap<String, String> request) {
-        IoParameters parameters = createParameters(request, locale);
+        IoParameters parameters = createParameters(timeseriesId, request, locale);
         checkAgainstTimespanRestriction(parameters.getTimespan());
         checkIfUnknownTimeseriesId(parameters, timeseriesId);
 
@@ -210,7 +210,7 @@ public class TimeseriesDataController extends BaseController {
                            @RequestHeader(value = Parameters.HttpHeader.ACCEPT_LANGUAGE,
                                required = false) String locale,
                            @RequestParam MultiValueMap<String, String> request) {
-        IoParameters parameters = createParameters(request, locale);
+        IoParameters parameters = createParameters(timeseriesId, request, locale);
         checkIfUnknownTimeseriesId(parameters, timeseriesId);
         processRawDataRequest(response, parameters);
     }
@@ -267,7 +267,7 @@ public class TimeseriesDataController extends BaseController {
                           @RequestHeader(value = Parameters.HttpHeader.ACCEPT_LANGUAGE, required = false) String locale,
                           @RequestParam(required = false) MultiValueMap<String, String> request)
             throws Exception {
-        IoParameters parameters = createParameters(request, locale);
+        IoParameters parameters = createParameters(timeseriesId, request, locale);
         checkIfUnknownTimeseriesId(parameters, timeseriesId);
         checkAgainstTimespanRestriction(parameters.getTimespan());
 
@@ -287,7 +287,8 @@ public class TimeseriesDataController extends BaseController {
                                    required = false) String locale,
                                @RequestParam(required = false) MultiValueMap<String, String> query)
             throws Exception {
-        IoParameters parameters = createParameters(query, locale).extendWith(Parameters.ZIP, Boolean.TRUE.toString());
+        IoParameters parameters = createParameters(timeseriesId, query, locale);
+        parameters.extendWith(Parameters.ZIP, Boolean.TRUE.toString());
         response.setContentType(Constants.APPLICATION_ZIP);
         getTimeseriesAsCsv(timeseriesId, parameters, response);
     }
@@ -302,7 +303,7 @@ public class TimeseriesDataController extends BaseController {
                          @RequestHeader(value = Parameters.HttpHeader.ACCEPT_LANGUAGE, required = false) String locale,
                          @RequestParam(required = false) MultiValueMap<String, String> request)
             throws Exception {
-        IoParameters parameters = createParameters(request, locale);
+        IoParameters parameters = createParameters(timeseriesId, request, locale);
         getTimeseriesAsCsv(timeseriesId, parameters, response);
     }
 
@@ -350,7 +351,7 @@ public class TimeseriesDataController extends BaseController {
                          @RequestHeader(value = Parameters.HttpHeader.ACCEPT_LANGUAGE, required = false) String locale,
                          @RequestParam(required = false) MultiValueMap<String, String> query)
             throws Exception {
-        IoParameters parameters = createParameters(query, locale);
+        IoParameters parameters = createParameters(timeseriesId, query, locale);
         checkAgainstTimespanRestriction(parameters.getTimespan());
         checkIfUnknownTimeseriesId(parameters, timeseriesId);
 

--- a/spi/src/main/java/org/n52/io/request/IoParameters.java
+++ b/spi/src/main/java/org/n52/io/request/IoParameters.java
@@ -418,11 +418,11 @@ public final class IoParameters implements Parameters {
      * @return a (probably empty) set of result times.
      */
     public Set<String> getResultTimes() {
-        csvToSet(getAsString(RESULTTIMES), this::validateTimestamp);
         Set<String> resultTimes = csvToSet(getAsString(RESULTTIMES));
         if (resultTimes.contains(RESULT_TIMES_VALUE_ALL)) {
             resultTimes.remove(RESULT_TIMES_VALUE_ALL);
         }
+        resultTimes.stream().forEach(this::validateTimestamp);
         Instant fromOldParameter = getResultTime();
         if (fromOldParameter != null) {
             resultTimes.add(fromOldParameter.toString());

--- a/spi/src/main/java/org/n52/io/response/dataset/TimeseriesMetadataOutput.java
+++ b/spi/src/main/java/org/n52/io/response/dataset/TimeseriesMetadataOutput.java
@@ -131,7 +131,10 @@ public class TimeseriesMetadataOutput extends QuantityDatasetOutput {
     @Override
     @JsonProperty("parameters")
     public DatasetParameters getDatasetParameters() {
-        return new AdaptedSeriesParameters(super.getDatasetParameters());
+        DatasetParameters datasetParameters = super.getDatasetParameters();
+        return datasetParameters != null
+                ? new AdaptedSeriesParameters(datasetParameters)
+                : null;
     }
 
     private static class AdaptedSeriesParameters extends DatasetParameters {


### PR DESCRIPTION
* Use default styling (instead of throwing IAE --> `HTTP 500`) when style is missing on a single chart request
* `TimeseriesDataController` was broken as the times series id hasn't been added to the `IoParameters` instance
* Condensed output of `/timeseries` serialized an empty `parameters` member