### PR TITLE
use metadata extension extras in timeseries metadata controller

### DIFF
--- a/rest/src/main/java/org/n52/web/ctrl/TimeseriesMetadataController.java
+++ b/rest/src/main/java/org/n52/web/ctrl/TimeseriesMetadataController.java
@@ -140,9 +140,8 @@ public class TimeseriesMetadataController extends ParameterRequestMappingAdapter
     }
 
     @SuppressWarnings("unchecked")
-    protected <T extends ParameterOutput> Optional<Map<String, Object>> getMetadataExtensionExtras(T output,
-                                                                                                   IoParameters parameters,
-                                                                                                   Class<? extends MetadataExtension<T>> clazz) {
+    protected <T extends ParameterOutput> Optional<Map<String, Object>> getMetadataExtensionExtras(
+            T output, IoParameters parameters, Class<? extends MetadataExtension<T>> clazz) {
         return getMetadataExtensions().stream()
                 .map(x -> (MetadataExtension<?>) x)
                 .filter(x -> clazz.isInstance(x))


### PR DESCRIPTION
Removed explicit declaration of extensions and used the `getMetadataExtensionExtras()` method.