### PR TITLE
Enables Fields-Query-Parameter on all Endpoints

### DIFF
--- a/io/src/test/java/org/n52/io/img/quantity/ChartRendererTest.java
+++ b/io/src/test/java/org/n52/io/img/quantity/ChartRendererTest.java
@@ -151,7 +151,8 @@ public class ChartRendererTest {
                 .setUom(OptionalOutput.of(""))
                 .setId("timeseries");
 
-        PlatformOutput platformOutput = new PlatformOutput(PlatformType.STATIONARY_INSITU);
+        PlatformOutput platformOutput = new PlatformOutput();
+        platformOutput.setPlatformType(OptionalOutput.of(PlatformType.STATIONARY_INSITU));
         platformOutput.setId("sta_1");
         platformOutput.setLabel(OptionalOutput.of("station"));
         datasetParameters.setPlatform(platformOutput);

--- a/spi/src/main/java/org/n52/io/geojson/FeatureOutputSerializer.java
+++ b/spi/src/main/java/org/n52/io/geojson/FeatureOutputSerializer.java
@@ -34,8 +34,6 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.vividsolutions.jts.geom.Geometry;
 import java.io.IOException;
-import java.util.Map;
-import java.util.Map.Entry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,33 +44,20 @@ public class FeatureOutputSerializer extends JsonSerializer<GeoJSONFeature> {
     @Override
     public void serialize(GeoJSONFeature value, JsonGenerator gen, SerializerProvider serializers)
             throws IOException, JsonProcessingException {
-        if (value.isSetGeometry()) {
             writeFeature(value, gen);
-        } else {
-            writeGeometryLessFeature(value, gen);
-        }
     }
 
     private void writeFeature(GeoJSONFeature value, JsonGenerator gen) throws IOException {
         gen.writeStartObject();
-        gen.writeStringField("type", "Feature");
         gen.writeStringField("id", value.getId());
-        gen.writeObjectField("properties", value.getProperties());
-        gen.writeObjectField("geometry", encodeGeometry(value));
-        gen.writeEndObject();
-    }
-
-    private void writeGeometryLessFeature(GeoJSONFeature value,
-            JsonGenerator gen) throws IOException {
-        gen.writeStartObject();
-        writeMap(value.getProperties(), gen);
-        gen.writeEndObject();
-    }
-
-    private void writeMap(Map<String, Object> map, JsonGenerator gen) throws IOException {
-        for (Entry<String, Object> entry : map.entrySet()) {
-            gen.writeObjectField(entry.getKey(), entry.getValue());
+        if (value.getProperties() != null) {
+            gen.writeObjectField("properties", value.getProperties());
         }
+        if (value.isSetGeometry()) {
+            gen.writeStringField("type", "Feature");
+            gen.writeObjectField("geometry", encodeGeometry(value));
+        }
+        gen.writeEndObject();
     }
 
     private Object encodeGeometry(GeoJSONFeature value) {

--- a/spi/src/main/java/org/n52/io/geojson/FeatureOutputSerializer.java
+++ b/spi/src/main/java/org/n52/io/geojson/FeatureOutputSerializer.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.vividsolutions.jts.geom.Geometry;
 import java.io.IOException;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,8 +51,9 @@ public class FeatureOutputSerializer extends JsonSerializer<GeoJSONFeature> {
     private void writeFeature(GeoJSONFeature value, JsonGenerator gen) throws IOException {
         gen.writeStartObject();
         gen.writeStringField("id", value.getId());
-        if (value.getProperties() != null) {
-            gen.writeObjectField("properties", value.getProperties());
+        Map<String, Object> properties = value.getProperties();
+        if (!properties.isEmpty()) {
+            gen.writeObjectField("properties", properties);
         }
         if (value.isSetGeometry()) {
             gen.writeStringField("type", "Feature");

--- a/spi/src/main/java/org/n52/io/response/GeometryInfo.java
+++ b/spi/src/main/java/org/n52/io/response/GeometryInfo.java
@@ -47,9 +47,11 @@ import com.vividsolutions.jts.geom.Geometry;
 @JsonSerialize(using = FeatureOutputSerializer.class, as = GeoJSONObject.class)
 public class GeometryInfo extends AbstractOutput implements GeoJSONFeature {
 
-    public static final String PLATFORM = "platform";
+    public static final String PROPERTIES = "properties";
 
     public static final String GEOMETRY_TYPE = "geometryType";
+
+    private static final String PLATFORM = "platform";
 
     private OptionalOutput<GeometryType> geometryType;
 
@@ -94,7 +96,7 @@ public class GeometryInfo extends AbstractOutput implements GeoJSONFeature {
 
     @Override
     public Geometry getGeometry() {
-        return getIfSerialized(geometry);
+        return getIfSet(geometry, true);
     }
 
     @Override
@@ -104,7 +106,7 @@ public class GeometryInfo extends AbstractOutput implements GeoJSONFeature {
 
     @Override
     public boolean isSetGeometry() {
-        return getGeometry() != null && !getGeometry().isEmpty();
+        return getIfSerialized(geometry) != null && !getGeometry().isEmpty();
     }
 
     @Override
@@ -121,21 +123,30 @@ public class GeometryInfo extends AbstractOutput implements GeoJSONFeature {
     }
 
     private String getUrlIdPrefix() {
-        return getType().getGeometryType();
+        return getIfSet(geometryType, true).getGeometryType();
     }
 
-    public String getGeometyType() {
-        return getType().getGeometryType();
+    public String getGeometryType() {
+        if (getIfSerialized(geometryType) != null) {
+            return getType().getGeometryType();
+        } else {
+            return null;
+        }
     }
 
     @Override
     public Map<String, Object> getProperties() {
         HashMap<String, Object> properties = new HashMap<>();
-        properties.put(GEOMETRY_TYPE, getGeometyType());
-        properties.put(PLATFORM, getPlatform());
-        properties.put(HREF, getHref());
-        properties.put(ID, getId());
+        nullSafePut(GEOMETRY_TYPE, getGeometryType(), properties);
+        nullSafePut(PLATFORM, getPlatform(), properties);
+        nullSafePut(HREF, getHref(), properties);
         return properties;
+    }
+
+        private void nullSafePut(String key, Object value, Map<String, Object> container) {
+        if (value != null) {
+            container.put(key, value);
+        }
     }
 
 }

--- a/spi/src/main/java/org/n52/io/response/PlatformOutput.java
+++ b/spi/src/main/java/org/n52/io/response/PlatformOutput.java
@@ -29,7 +29,6 @@
 package org.n52.io.response;
 
 import java.util.Collection;
-import java.util.List;
 
 import org.n52.io.geojson.GeoJSONGeometrySerializer;
 import org.n52.io.response.dataset.DatasetOutput;
@@ -46,15 +45,18 @@ import com.vividsolutions.jts.geom.Geometry;
  */
 public class PlatformOutput extends OutputWithParameters {
 
+    public static final String DATASETS = "datasets";
+    public static final String GEOMETRY = "geometry";
+    public static final String PLATFORMTYPE = "platformtype";
+
     // TODO use plain string in output and let repository assert correctness
-    private final PlatformType platformType;
+    private OptionalOutput<PlatformType> platformType;
 
-    private Collection<DatasetOutput> datasets;
+    private OptionalOutput<Collection<DatasetOutput>> datasets;
 
-    private Geometry geometry;
+    private OptionalOutput<Geometry> geometry;
 
-    public PlatformOutput(PlatformType platformType) {
-        this.platformType = platformType;
+    public PlatformOutput() {
     }
 
     @Override
@@ -67,38 +69,50 @@ public class PlatformOutput extends OutputWithParameters {
     }
 
     public String getPlatformType() {
-        return getType().getPlatformType();
+        if (getIfSerialized(platformType) != null) {
+            return getType().getPlatformType();
+        } else {
+            return null;
+        }
+    }
+
+    public PlatformOutput setPlatformType(OptionalOutput<PlatformType> platformtype) {
+        this.platformType = platformtype;
+        return this;
     }
 
     @JsonIgnore
     public PlatformType getType() {
-        return platformType != null
-                ? platformType
+        PlatformType type = getIfSet(platformType, true);
+        return type != null
+                ? type
                 // stay backward compatible
                 : PlatformType.STATIONARY_INSITU;
     }
 
     @Override
     public PlatformOutput setId(String id) {
-        super.setId(getType().createId(id));
+        if (getType() != null) {
+            super.setId(getType().createId(id));
+        }
         return this;
     }
 
     public Collection<DatasetOutput> getDatasets() {
-        return datasets;
+        return getIfSerializedCollection(datasets);
     }
 
-    public PlatformOutput setDatasets(List<DatasetOutput> series) {
+    public PlatformOutput setDatasets(OptionalOutput<Collection<DatasetOutput>> series) {
         this.datasets = series;
         return this;
     }
 
     @JsonSerialize(using = GeoJSONGeometrySerializer.class)
     public Geometry getGeometry() {
-        return geometry;
+        return getIfSerialized(geometry);
     }
 
-    public PlatformOutput setGeometry(Geometry geometry) {
+    public PlatformOutput setGeometry(OptionalOutput<Geometry> geometry) {
         this.geometry = geometry;
         return this;
     }

--- a/spi/src/main/java/org/n52/io/response/dataset/DatasetOutput.java
+++ b/spi/src/main/java/org/n52/io/response/dataset/DatasetOutput.java
@@ -41,7 +41,7 @@ public class DatasetOutput<V extends AbstractValue< ? >, R extends ReferenceValu
 
     public static final String VALUE_TYPE = "valuetype";
     public static final String PLATFORM_TYPE = "platformtype";
-    public static final String DATASET_PARAMETERS = "datasetparameters";
+    public static final String DATASET_PARAMETERS = "parameters";
     public static final String REFERENCE_VALUES = "referencevalues";
     public static final String FIRST_VALUE = "firstvalue";
     public static final String LAST_VALUE = "lastvalue";

--- a/spi/src/main/java/org/n52/io/response/dataset/StationOutput.java
+++ b/spi/src/main/java/org/n52/io/response/dataset/StationOutput.java
@@ -49,7 +49,7 @@ import com.vividsolutions.jts.geom.Geometry;
 @JsonSerialize(using = FeatureOutputSerializer.class, as = GeoJSONObject.class)
 public class StationOutput extends AbstractOutput implements GeoJSONFeature {
 
-    public static final String TIMESERIES = "timeseries";
+    public static final String PROPERTIES = "properties";
     public static final String GEOMETRY = "geometry";
 
     private OptionalOutput<Map<String, DatasetParameters>> timeseries;
@@ -81,16 +81,12 @@ public class StationOutput extends AbstractOutput implements GeoJSONFeature {
 
     @Override
     public Map<String, Object> getProperties() {
-
-        // XXX how to apply OptionalOutput here?
-
         Map<String, Object> properties = new HashMap<>();
-        nullSafePut("id", getId(), properties);
         nullSafePut("label", getLabel(), properties);
         nullSafePut("domainId", getDomainId(), properties);
         nullSafePut("href", getHref(), properties);
         nullSafePut("rawFormats", getRawFormats(), properties);
-        nullSafePut(TIMESERIES, getTimeseries(), properties);
+        nullSafePut("timeseries", getTimeseries(), properties);
         return properties;
     }
 

--- a/spi/src/main/java/org/n52/series/spi/geo/TransformingPlatformOutputService.java
+++ b/spi/src/main/java/org/n52/series/spi/geo/TransformingPlatformOutputService.java
@@ -89,9 +89,12 @@ public class TransformingPlatformOutputService extends ParameterService<Platform
         return platform;
     }
 
-    private void transformInline(IoParameters query, PlatformOutput platform) {
+    private void transformInline(IoParameters parameters, PlatformOutput platform) {
         Geometry geometry = platform.getGeometry();
-        platform.setGeometry(transformationService.transform(geometry, query));
+        platform.setValue(PlatformOutput.GEOMETRY,
+                transformationService.transform(geometry, parameters),
+                parameters,
+                platform::setGeometry);
     }
 
 }

--- a/spi/src/test/java/org/n52/io/response/PlatformOutputTest.java
+++ b/spi/src/test/java/org/n52/io/response/PlatformOutputTest.java
@@ -37,7 +37,8 @@ public class PlatformOutputTest {
 
     @Test
     public void when_createdMobileRemote_then_hrefIncludesPrefix() {
-        PlatformOutput platform = new PlatformOutput(PlatformType.MOBILE_REMOTE);
+        PlatformOutput platform = new PlatformOutput();
+        platform.setPlatformType(OptionalOutput.of(PlatformType.MOBILE_REMOTE));
         platform.setHrefBase(OptionalOutput.of("http://localhost/context"));
         platform.setId("12");
 
@@ -46,7 +47,8 @@ public class PlatformOutputTest {
 
     @Test
     public void when_createdStationaryRemote_then_hrefIncludesPrefix() {
-        PlatformOutput platform = new PlatformOutput(PlatformType.STATIONARY_REMOTE);
+        PlatformOutput platform = new PlatformOutput();
+        platform.setPlatformType(OptionalOutput.of(PlatformType.STATIONARY_REMOTE));
         platform.setHrefBase(OptionalOutput.of("http://localhost/context"));
         platform.setId("12");
 
@@ -55,7 +57,8 @@ public class PlatformOutputTest {
 
     @Test
     public void when_createdStationaryInsitu_then_hrefIncludesPrefix() {
-        PlatformOutput platform = new PlatformOutput(PlatformType.STATIONARY_INSITU);
+        PlatformOutput platform = new PlatformOutput();
+        platform.setPlatformType(OptionalOutput.of(PlatformType.STATIONARY_INSITU));
         platform.setHrefBase(OptionalOutput.of("http://localhost/context"));
         platform.setId("12");
 
@@ -64,7 +67,8 @@ public class PlatformOutputTest {
 
     @Test
     public void when_createdMobileInsitu_then_hrefIncludesPrefix() {
-        PlatformOutput platform = new PlatformOutput(PlatformType.MOBILE_INSITU);
+        PlatformOutput platform = new PlatformOutput();
+        platform.setPlatformType(OptionalOutput.of(PlatformType.MOBILE_INSITU));
         platform.setHrefBase(OptionalOutput.of("http://localhost/context"));
         platform.setId("12");
 
@@ -73,7 +77,8 @@ public class PlatformOutputTest {
 
     @Test
     public void when_havingExplicitHref_then_hrefNotIncludingHrefBase() {
-        PlatformOutput platform = new PlatformOutput(PlatformType.MOBILE_INSITU);
+        PlatformOutput platform = new PlatformOutput();
+        platform.setPlatformType(OptionalOutput.of(PlatformType.MOBILE_INSITU));
         platform.setHref(OptionalOutput.of("http://localhost/otherContext/12"));
         platform.setHrefBase(OptionalOutput.of("http://localhost/context"));
         platform.setId("12");


### PR DESCRIPTION
Adds support to previously unsupported Endpoints `/geometries`, `/platforms`,`/stations`.

Additionally:
- platformType in `/platforms` is now optional
- FeatureOutputSerializer is now consistent independent of presence of Geometry