### PR TITLE
Feature: Improve CSV Export

### DIFF
--- a/io/pom.xml
+++ b/io/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.n52.series-api</groupId>
         <artifactId>series-rest-api</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>io</artifactId>
     <packaging>jar</packaging>

--- a/io/src/main/java/org/n52/io/type/quantity/handler/csv/QuantityCsvIoHandler.java
+++ b/io/src/main/java/org/n52/io/type/quantity/handler/csv/QuantityCsvIoHandler.java
@@ -128,37 +128,37 @@ public class QuantityCsvIoHandler extends CsvIoHandler<Data<QuantityValue>> {
 
     private void writeAsZipStream(DataCollection<Data<QuantityValue>> data, OutputStream stream) throws IOException {
         try (ZipOutputStream zipStream = new ZipOutputStream(stream)) {
-            String filename = "";
+            StringBuilder filename = new StringBuilder();
             Data<QuantityValue> series;
             if (seriesMetadatas.size() == 1) {
                 Map<String, String> metadataMap = parseMetadata(seriesMetadatas.get(0));
-                filename += metadataMap.get(STATION) + "_";
-                filename += metadataMap.get(PHENOMENON) + "_";
-                filename += metadataMap.get(PROCEDURE);
+                filename.append(metadataMap.get(STATION) + "_");
+                filename.append(metadataMap.get(PHENOMENON) + "_");
+                filename.append(metadataMap.get(PROCEDURE));
                 
                 // Check if filename is exceeding 255 (including extension) character bound of most Filesystems.
                 // Fallback to only station name if that is the case
                 if (filename.length() > 251) {
-                    filename = metadataMap.get(STATION);
+                    filename.append(metadataMap.get(STATION));
                 }
             } else {
                 String prefix = "multiple_datasets_";
-                filename = prefix;
+                filename.append(prefix);
                 for (DatasetOutput metadata : seriesMetadatas) {
-                    filename += getStation(metadata) + "_";
+                    filename.append(getStation(metadata) + "_");
                 }
                 // Remove trailing underscore
-                filename = filename.substring(0, filename.length() - 1);
+                filename.deleteCharAt(filename.length() - 1);
 
                 // Check if filename is exceeding 255 (including extension) character bound of most Filesystems.
                 // Fallback to UUID if that is the case
                 if (filename.length() > 251) {
-                    filename = prefix + UUID.randomUUID();
+                    filename.append(prefix + UUID.randomUUID());
                 }
             }
-            filename += ".csv";
+            filename.append(".csv");
 
-            zipStream.putNextEntry(new ZipEntry(filename));
+            zipStream.putNextEntry(new ZipEntry(filename.toString()));
             writeHeader(zipStream);
             writeData(data, zipStream);
             zipStream.closeEntry();

--- a/io/src/main/java/org/n52/io/type/quantity/handler/csv/QuantityCsvIoHandler.java
+++ b/io/src/main/java/org/n52/io/type/quantity/handler/csv/QuantityCsvIoHandler.java
@@ -26,6 +26,7 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
+
 package org.n52.io.type.quantity.handler.csv;
 
 import java.io.BufferedOutputStream;
@@ -55,6 +56,13 @@ import org.n52.io.response.dataset.quantity.QuantityValue;
 // TODO extract non quantity specifics to csvhandler
 
 public class QuantityCsvIoHandler extends CsvIoHandler<Data<QuantityValue>> {
+    
+    private static final String STATION = "station";
+    private static final String PHENOMENON = "phenomenon";
+    private static final String PROCEDURE = "procedure";
+    private static final String UOM = "uom";
+    private static final String TIME = "time";
+    private static final String VALUE = "value";
 
     private static final Charset UTF8 = Charset.forName("UTF-8");
 
@@ -81,20 +89,11 @@ public class QuantityCsvIoHandler extends CsvIoHandler<Data<QuantityValue>> {
 
     @Override
     protected String[] getHeader() {
-        return new String[] {
-            "station",
-            "phenomenon",
-            "procedure",
-            "uom",
-            "time",
-            "value"
-        };
+        return new String[] {STATION, PHENOMENON, PROCEDURE, UOM, TIME, VALUE};
     }
 
     public void setTokenSeparator(String tokenSeparator) {
-        this.tokenSeparator = tokenSeparator == null
-                ? this.tokenSeparator
-                : tokenSeparator;
+        this.tokenSeparator = tokenSeparator == null ? this.tokenSeparator : tokenSeparator;
     }
 
     public void setIncludeByteOrderMark(boolean byteOrderMark) {
@@ -128,26 +127,27 @@ public class QuantityCsvIoHandler extends CsvIoHandler<Data<QuantityValue>> {
 
     private void writeAsZipStream(DataCollection<Data<QuantityValue>> data, OutputStream stream) throws IOException {
         try (ZipOutputStream zipStream = new ZipOutputStream(stream)) {
-        	String filename = "";
-        	Data<QuantityValue> series;
-        	if (seriesMetadatas.size() == 1) {
-        		Map<String,String> metadataMap =  parseMetadata(seriesMetadatas.get(0));
-        		filename += metadataMap.get("station") + "_";
-        		filename += metadataMap.get("procedure") + "_";
-        		filename += metadataMap.get("phenomenon") + "_";
-        		series = data.getSeries(seriesMetadatas.get(0).getId());                
-        		
-        		// Assuming Elements are in order (by date)
-        		Long startValue = series.getValues().get(0).getTimestart();
-                Long start = (startValue != null)? startValue : series.getValues().get(0).getTimeend(); 
-        		filename += getISO8601Time(start, series.getValues().get(series.getValues().size()-1).getTimeend());
-        		
-        	} else {
-        		//TODO: create useful naming scheme for downloading multiple Datasets with different timestamps at once
-        		filename += "multiple-datasets-";
-        	}
-        	filename += ".csv";
-        	
+            String filename = "";
+            Data<QuantityValue> series;
+            if (seriesMetadatas.size() == 1) {
+                Map<String, String> metadataMap = parseMetadata(seriesMetadatas.get(0));
+                filename += metadataMap.get(STATION) + "_";
+                filename += metadataMap.get(PHENOMENON) + "_";
+                filename += metadataMap.get(PROCEDURE) + "_";
+                series = data.getSeries(seriesMetadatas.get(0).getId());
+
+                // Assuming Elements are in order (by date)
+                Long startValue = series.getValues().get(0).getTimestart();
+                Long start = (startValue != null) ? startValue : series.getValues().get(0).getTimeend();
+                filename += getISO8601Time(start, series.getValues().get(series.getValues().size() - 1).getTimeend());
+
+            } else {
+                // TODO: create useful naming scheme for downloading multiple Datasets with
+                // different timestamps at once
+                filename += "multiple-datasets-";
+            }
+            filename += ".csv";
+
             zipStream.putNextEntry(new ZipEntry(filename));
             writeHeader(zipStream);
             writeData(data, zipStream);
@@ -172,12 +172,12 @@ public class QuantityCsvIoHandler extends CsvIoHandler<Data<QuantityValue>> {
     }
 
     private void writeData(DatasetOutput metadata, Data<QuantityValue> series, OutputStream stream) throws IOException {
-        Map<String,String> metadataMap = parseMetadata(metadata); 
+        Map<String, String> metadataMap = parseMetadata(metadata);
         String value0 = metadataMap.get(getHeader()[0]);
         String value1 = metadataMap.get(getHeader()[1]);
         String value2 = metadataMap.get(getHeader()[2]);
         String value3 = metadataMap.get(getHeader()[3]);
-        
+
         for (QuantityValue timeseriesValue : series.getValues()) {
             String[] values = new String[getHeader().length];
             values[0] = value0;
@@ -203,36 +203,29 @@ public class QuantityCsvIoHandler extends CsvIoHandler<Data<QuantityValue>> {
             sb.append(tokenSeparator);
         }
         sb.deleteCharAt(sb.lastIndexOf(tokenSeparator));
-        return sb.append("\n")
-                 .toString();
+        return sb.append("\n").toString();
     }
-    
-    private Map<String,String> parseMetadata(DatasetOutput metadata) {
-        Map<String,String> map = new HashMap<String,String>();
+
+    private Map<String, String> parseMetadata(DatasetOutput metadata) {
+        Map<String, String> map = new HashMap<String, String>();
         String station = null;
-        ParameterOutput platform = metadata.getDatasetParameters(true)
-                                           .getPlatform();
+        ParameterOutput platform = metadata.getDatasetParameters(true).getPlatform();
         if (platform == null) {
             TimeseriesMetadataOutput output = (TimeseriesMetadataOutput) metadata;
-            station = output.getStation()
-                            .getLabel();
+            station = output.getStation().getLabel();
         } else {
             station = platform.getLabel();
         }
-        map.put("station", station);
-        map.put("phenomenon", metadata.getDatasetParameters(true)
-                                      .getPhenomenon()
-                                      .getLabel());
-        
-        map.put("procedure", metadata.getDatasetParameters(true)
-        						     .getProcedure()
-        						     .getLabel());
-        map.put("uom", metadata.getUom());
+        map.put(STATION, station);
+        map.put(PHENOMENON, metadata.getDatasetParameters(true).getPhenomenon().getLabel());
+
+        map.put(PROCEDURE, metadata.getDatasetParameters(true).getProcedure().getLabel());
+        map.put(UOM, metadata.getUom());
         return map;
     }
-    
+
     private String getISO8601Time(Long start, Long end) {
-        return ((start == null)? "" : (new DateTime(start).toString() + "/")) + new DateTime(end).toString();
+        return ((start == null) ? "" : (new DateTime(start).toString() + "/")) + new DateTime(end).toString();
     }
 
 }

--- a/io/src/main/java/org/n52/io/type/quantity/handler/csv/QuantityCsvIoHandler.java
+++ b/io/src/main/java/org/n52/io/type/quantity/handler/csv/QuantityCsvIoHandler.java
@@ -134,24 +134,8 @@ public class QuantityCsvIoHandler extends CsvIoHandler<Data<QuantityValue>> {
                 Map<String, String> metadataMap = parseMetadata(seriesMetadatas.get(0));
                 filename += metadataMap.get(STATION) + "_";
                 filename += metadataMap.get(PHENOMENON) + "_";
-                filename += metadataMap.get(PROCEDURE) + "_";
-                series = data.getSeries(seriesMetadatas.get(0).getId());
-
-                // Assuming Elements are in order (by date)
-                // This might fail if there are no Elements.
-                try {
-                    List<QuantityValue> values = series.getValues();
-                    // Determines if Time Intervals or Timestamps are used
-                    Long start = values.get(0).getTimestart();
-                    
-                    Long startTime = (start != null) ? start : values.get(0).getTimestamp();
-                    Long endTime = (start != null) ? values.get(values.size() - 1).getTimeend() :
-                                                     values.get(series.getValues().size() - 1).getTimestamp();
-                    filename += getISO8601Time(startTime, endTime, "%2F");
-                } catch (Exception e) {
-                    // Remove trailing underscore
-                    filename = filename.substring(0, filename.length() - 1);
-                }
+                filename += metadataMap.get(PROCEDURE);
+                
                 // Check if filename is exceeding 255 (including extension) character bound of most Filesystems.
                 // Fallback to only station name if that is the case
                 if (filename.length() > 251) {
@@ -208,7 +192,7 @@ public class QuantityCsvIoHandler extends CsvIoHandler<Data<QuantityValue>> {
         for (QuantityValue timeseriesValue : series.getValues()) {
             Long timestart = timeseriesValue.getTimestart();
             Long timeend = (timestart != null) ? timeseriesValue.getTimeend() : timeseriesValue.getTimestamp();
-            values[4] = getISO8601Time(timestart, timeend, "/");
+            values[4] = getISO8601Time(timestart, timeend);
             values[5] = numberformat.format(timeseriesValue.getValue());
             writeCsvLine(csvEncode(values), stream);
         }
@@ -237,8 +221,8 @@ public class QuantityCsvIoHandler extends CsvIoHandler<Data<QuantityValue>> {
         return map;
     }
 
-    private String getISO8601Time(Long start, Long end, String separator) {
-        return ((start == null) ? "" : (new DateTime(start).toString() + separator)) + new DateTime(end).toString();
+    private String getISO8601Time(Long start, Long end) {
+        return ((start == null) ? "" : (new DateTime(start).toString() + "/")) + new DateTime(end).toString();
     }
 
     private String getStation(DatasetOutput metadata) {

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.n52.series-api</groupId>
     <artifactId>series-rest-api</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Series REST API</name>
     <url>http://52north.org/communities/sensorweb/</url>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.n52.series-api</groupId>
         <artifactId>series-rest-api</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>rest</artifactId>
     <packaging>jar</packaging>

--- a/rest/src/main/java/org/n52/web/ctrl/DataController.java
+++ b/rest/src/main/java/org/n52/web/ctrl/DataController.java
@@ -30,6 +30,7 @@ package org.n52.web.ctrl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -83,6 +84,12 @@ import org.springframework.web.servlet.ModelAndView;
     "application/json"
 })
 public class DataController extends BaseController {
+
+    private static final String CONTENT_DISPOSITION_HEADER = "Content-Disposition";
+
+    private static final String CONTENT_DISPOSITION_VALUE_TEMPLATE = "attachment; filename=\"Data_for_Dataset_";
+
+    private static final String SHOWTIMEINTERVALS_QUERY_OPTION = "showTimeIntervals";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DataController.class);
 
@@ -262,6 +269,8 @@ public class DataController extends BaseController {
         final String datasetType = getValueType(parameters);
         String outputFormat = Constants.APPLICATION_PDF;
         response.setContentType(outputFormat);
+        response.setHeader(CONTENT_DISPOSITION_HEADER, CONTENT_DISPOSITION_VALUE_TEMPLATE + datasetId + ".pdf\"");
+
         createIoFactory(datasetType).setParameters(parameters)
                                     .createHandler(outputFormat)
                                     .writeBinary(response.getOutputStream());
@@ -278,6 +287,9 @@ public class DataController extends BaseController {
                                          required = false) String locale,
                                      @RequestParam(required = false) MultiValueMap<String, String> query)
             throws Exception {
+        // Needed to retrieve Time Ends from Database
+        query.putIfAbsent(SHOWTIMEINTERVALS_QUERY_OPTION, Arrays.asList(Boolean.TRUE.toString()));
+
         IoParameters parameters = createParameters(datasetId, query, locale);
         LOGGER.debug("get data collection zip for '{}' with query: {}", datasetId, parameters);
         checkAgainstTimespanRestriction(parameters.getTimespan());
@@ -285,6 +297,7 @@ public class DataController extends BaseController {
 
         response.setCharacterEncoding(DEFAULT_RESPONSE_ENCODING);
         response.setContentType(Constants.APPLICATION_ZIP);
+        response.setHeader(CONTENT_DISPOSITION_HEADER, CONTENT_DISPOSITION_VALUE_TEMPLATE + datasetId + ".zip\"");
 
         final String datasetType = getValueType(parameters);
         createIoFactory(datasetType).setParameters(parameters)
@@ -303,17 +316,27 @@ public class DataController extends BaseController {
                                    required = false) String locale,
                                @RequestParam(required = false) MultiValueMap<String, String> query)
             throws Exception {
+        // Needed to retrieve Time Ends from Database
+        query.putIfAbsent(SHOWTIMEINTERVALS_QUERY_OPTION, Arrays.asList(Boolean.TRUE.toString()));
+
         IoParameters parameters = createParameters(datasetId, query, locale);
         LOGGER.debug("get data collection csv for '{}' with query: {}", datasetId, parameters);
         checkAgainstTimespanRestriction(parameters.getTimespan());
         checkForUnknownDatasetId(parameters, datasetId);
 
+        String extension = ".";
         response.setCharacterEncoding(DEFAULT_RESPONSE_ENCODING);
-        if (Boolean.parseBoolean(parameters.getOther("zip"))) {
+        if (Boolean.parseBoolean(parameters.getOther(Parameters.ZIP))) {
             response.setContentType(Constants.APPLICATION_ZIP);
+            extension += Parameters.ZIP;
         } else {
             response.setContentType(Constants.TEXT_CSV);
+            extension += "csv";
         }
+        response.setHeader(CONTENT_DISPOSITION_HEADER, CONTENT_DISPOSITION_VALUE_TEMPLATE
+                            + datasetId
+                            + extension
+                            + "\"");
 
         final String datasetType = getValueType(parameters);
         createIoFactory(datasetType).setParameters(parameters)

--- a/rest/src/main/java/org/n52/web/ctrl/TimeseriesDataController.java
+++ b/rest/src/main/java/org/n52/web/ctrl/TimeseriesDataController.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -89,6 +90,14 @@ import org.springframework.web.servlet.ModelAndView;
     "application/json"
 })
 public class TimeseriesDataController extends BaseController {
+
+    private static final String CONTENT_DISPOSITION_HEADER = "Content-Disposition";
+
+    private static final String CONTENT_DISPOSITION_VALUE_TEMPLATE = "attachment; filename=\"Data_for_Timeseries_";
+
+    private static final String DEFAULT_RESPONSE_ENCODING = "UTF-8";
+
+    private static final String SHOWTIMEINTERVALS_QUERY_OPTION = "showTimeIntervals";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TimeseriesDataController.class);
 
@@ -170,6 +179,9 @@ public class TimeseriesDataController extends BaseController {
         IoParameters parameters = createParameters(timeseriesId, request, locale);
         checkAgainstTimespanRestriction(parameters.getTimespan());
         checkIfUnknownTimeseriesId(parameters, timeseriesId);
+
+        response.setCharacterEncoding(DEFAULT_RESPONSE_ENCODING);
+        response.setContentType(Constants.APPLICATION_JSON);
 
         // TODO add paging
         DataCollection<Data<QuantityValue>> seriesData = getTimeseriesData(parameters);
@@ -277,7 +289,10 @@ public class TimeseriesDataController extends BaseController {
         checkIfUnknownTimeseriesId(parameters, timeseriesId);
         checkAgainstTimespanRestriction(parameters.getTimespan());
 
+        response.setCharacterEncoding(DEFAULT_RESPONSE_ENCODING);
         response.setContentType(Constants.APPLICATION_PDF);
+        response.setHeader(CONTENT_DISPOSITION_HEADER, CONTENT_DISPOSITION_VALUE_TEMPLATE + timeseriesId + ".pdf\"");
+
         createIoFactory(parameters).createHandler(Constants.APPLICATION_PDF)
                                    .writeBinary(response.getOutputStream());
     }
@@ -293,9 +308,12 @@ public class TimeseriesDataController extends BaseController {
                                    required = false) String locale,
                                @RequestParam(required = false) MultiValueMap<String, String> query)
             throws Exception {
+        // Needed to retrieve Time Ends from Database
+        query.putIfAbsent(SHOWTIMEINTERVALS_QUERY_OPTION, Arrays.asList(Boolean.TRUE.toString()));
+
         IoParameters parameters = createParameters(timeseriesId, query, locale);
         parameters = parameters.extendWith(Parameters.ZIP, Boolean.TRUE.toString());
-        response.setContentType(Constants.APPLICATION_ZIP);
+
         getTimeseriesAsCsv(timeseriesId, parameters, response);
     }
 
@@ -307,23 +325,34 @@ public class TimeseriesDataController extends BaseController {
     public void getAsCsv(HttpServletResponse response,
                          @PathVariable String timeseriesId,
                          @RequestHeader(value = Parameters.HttpHeader.ACCEPT_LANGUAGE, required = false) String locale,
-                         @RequestParam(required = false) MultiValueMap<String, String> request)
+                         @RequestParam(required = false) MultiValueMap<String, String> query)
             throws Exception {
-        IoParameters parameters = createParameters(timeseriesId, request, locale);
+        // Needed to retrieve Time Ends from Database
+        query.putIfAbsent(SHOWTIMEINTERVALS_QUERY_OPTION, Arrays.asList(Boolean.TRUE.toString()));
+
+        IoParameters parameters = createParameters(timeseriesId, query, locale);
         getTimeseriesAsCsv(timeseriesId, parameters, response);
-    }
+}
+
 
     private void getTimeseriesAsCsv(String timeseriesId, IoParameters parameters, HttpServletResponse response)
             throws IoHandlerException, DatasetFactoryException, URISyntaxException, MalformedURLException, IOException {
         checkAgainstTimespanRestriction(parameters.getTimespan());
         checkIfUnknownTimeseriesId(parameters, timeseriesId);
 
-        response.setCharacterEncoding("UTF-8");
+        response.setCharacterEncoding(DEFAULT_RESPONSE_ENCODING);
+        String extension = ".";
         if (Boolean.parseBoolean(parameters.getOther(Parameters.ZIP))) {
             response.setContentType(Constants.APPLICATION_ZIP);
+            extension += Parameters.ZIP;
         } else {
             response.setContentType(Constants.TEXT_CSV);
+            extension += "csv";
         }
+        response.setHeader(CONTENT_DISPOSITION_HEADER, CONTENT_DISPOSITION_VALUE_TEMPLATE
+                           + timeseriesId
+                           + extension
+                           + "\"");
         createIoFactory(parameters).createHandler(Constants.TEXT_CSV)
                                    .writeBinary(response.getOutputStream());
     }
@@ -362,6 +391,8 @@ public class TimeseriesDataController extends BaseController {
         checkIfUnknownTimeseriesId(parameters, timeseriesId);
 
         response.setContentType(Constants.IMAGE_PNG);
+        response.setHeader(CONTENT_DISPOSITION_HEADER, CONTENT_DISPOSITION_VALUE_TEMPLATE + timeseriesId + ".png\"");
+
         createIoFactory(parameters).createHandler(Constants.IMAGE_PNG)
                                    .writeBinary(response.getOutputStream());
     }

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.n52.series-api</groupId>
         <artifactId>series-rest-api</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>spi</artifactId>
     <name>Series REST API - SPI module</name>

--- a/web-resources/pom.xml
+++ b/web-resources/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>series-rest-api</artifactId>
         <groupId>org.n52.series-api</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <packaging>jar</packaging>
     <name>Series REST API - Web Resources</name>

--- a/web-resources/src/main/docs/_data/swagger.yaml
+++ b/web-resources/src/main/docs/_data/swagger.yaml
@@ -407,6 +407,7 @@ paths:
         - $ref: '#/parameters/expandedParam'
         - $ref: '#/parameters/timespanParam'
         - $ref: '#/parameters/resultTimesParam'
+        - $ref: '#/parameters/showTimeIntervalsParam'
       responses:
         '200':
           description: Data for a given `timespan` in a requested output format
@@ -544,6 +545,7 @@ paths:
         - $ref: '#/parameters/generalizeParam'
         - $ref: '#/parameters/formatParam'
         - $ref: '#/parameters/base64Param'
+        - $ref: '#/parameters/showTimeIntervalsParam'
       responses:
         '200':
           description: Data for a given `timespan` in a requested output format
@@ -1396,7 +1398,13 @@ parameters:
       Filter data which is available for different result times. Query `/extras?fields=resultTimes` beforehand to get
       a list of result times or add `resultTimes=all` to get all data classified by result time. In case of `resultTime`
       is missing from Query, those data will be returned which belongs to the oldest result time.
-        
+  showTimeIntervalsParam:
+    name: showTimeIntervals
+    in: query
+    type: boolean
+    collectionFormat: csv
+    description: |
+      Select whether Time fields in the output shall be returned using a single Timestamp or a Time Interval.   
 definitions:
   SimpleDataRequest:
     type: object


### PR DESCRIPTION
 * Added dynamic Filename Generation to CSV Export. Files are now named based on the following schema:  `<system>_<sensor>_<phenomenon>`
 * Fused `timestart` and `timeend` columns into single `time` column. If the `showTimeIntervals` Query Parameter (default: true) is present in the query options, Time is output as ISO 8601 Time Intervals. If the parameter is omitted single Timestamps are returned.
 * Added Content-Disposition Header to rename downloaded File to more useful name.
 * Added changes to documentation
 * Bumped minor Version